### PR TITLE
replace xrange by range for python 3 compatibility

### DIFF
--- a/sample_generator.py
+++ b/sample_generator.py
@@ -75,9 +75,9 @@ class AsymmetricDoubleWell(BrownianDynamics):
         r"""generate nsteps sample points"""
         x = np.zeros(shape=(nsteps+1,))
         x[0] = x0
-        for t in xrange(nsteps):
+        for t in range(nsteps):
             q = x[t]
-            for s in xrange(nskip):
+            for s in range(nskip):
                 q = self.step(q)
             x[t+1] = q
         return x
@@ -93,9 +93,9 @@ class FoldingModel(BrownianDynamics):
         r"""generate nsteps sample points"""
         rvec = np.zeros(shape=(nsteps+1, self.dim))
         rvec[0, :] = rvec0[:]
-        for t in xrange(nsteps):
+        for t in range(nsteps):
             q = rvec[t, :]
-            for s in xrange(nskip):
+            for s in range(nskip):
                 q = self.step(q)
             rvec[t+1, :] = q[:]
         return rvec


### PR DESCRIPTION
In Python 3, the old range function was removed and xrange was renamed to range. Therefore, there is no xrange function in Python 3 anymore. If memory is not a constraint, the best way to ensure compatibility with Python 2 and Python 3 is to use the range function (even though it requires more memory than xrange when using Python 2).

See also: http://python3porting.com/differences.html#range-and-xrange
